### PR TITLE
fix(deps): use dotnet 6 gitpod base image

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-dotnet
+FROM gitpod/workspace-dotnet:2022-11-09-13-54-49
 
 # Install custom tools, runtimes, etc.
 # For example "bastet", a command-line tetris clone:


### PR DESCRIPTION
Currently we are relying on the .net 6 SDK. Because newer versions of the gitpod base image bring .net 7, this commit selects a tag which has .net 6 installed.

See also:
https://github.com/small-coding-dojo/yascr22-golf-tennis/pull/3/commits/390c52ebf39fdc7e4b0fe7febf9ed0373f70239e